### PR TITLE
fix the class that without semicolon

### DIFF
--- a/newcoder/04_reConstructBinaryTree.cc
+++ b/newcoder/04_reConstructBinaryTree.cc
@@ -192,7 +192,7 @@ public:
 		TreeNode* right;
 		TreeNode(int value):val(value), left(nullptr), right(nullptr){}
 	};
-}
+};
 
 int main(int argc, char** argv) {
 


### PR DESCRIPTION
how can you make sense without a semicolon after the class definition?